### PR TITLE
Fix quaternion pole issue: joint twisting for visuals.

### DIFF
--- a/demo/pfnn.cpp
+++ b/demo/pfnn.cpp
@@ -1037,7 +1037,7 @@ static void reset(glm::vec2 position) {
   ArrayXf Yp = pfnn->Ymean;
 
   glm::vec3 root_position = glm::vec3(position.x, heightmap->sample(position), position.y);
-  glm::mat3 root_rotation = glm::mat3();
+  glm::mat3 root_rotation = glm::identity<glm::mat3>();
   
   for (int i = 0; i < Trajectory::LENGTH; i++) {
     trajectory->positions[i] = root_position;

--- a/gait_v3.py
+++ b/gait_v3.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Jun  6 16:15:32 2019
+
+@author: Administrator
+"""
+
+import os
+import pandas as pd
+import numpy as np
+import re
+
+
+def gait(bvh,txt):        
+    with open(txt) as f1:    
+        list1=[]
+        list2=[]
+        list3=[]
+        list4=[]
+        for line in f1.readlines():
+            if line[0].isdigit():
+                if line.endswith('scol\n') or line.endswith('ecol\n') or line.endswith('ecol'):
+                    a=re.findall(r'\d+',line)
+                    list4+=a
+                    b=re.findall(r'[a-z]+',line)
+                    list3+=b                    
+                else:
+                    a=re.findall(r'\d+',line)
+                    list2+=a
+                    b=re.findall(r'[a-z]+',line)
+                    list1+=b
+                
+    with open(bvh) as f2:    
+        for line in f2.readlines():
+            if line.startswith('Frames'):
+                #print(re.split(': |:\t',line)[1])
+                frames=re.split(': |:\t',line)[1]
+                frames=eval(frames)
+#    print(list1)  
+#    print(list2)  
+#    print(list3)
+#    print(list4)
+    print(bvh)
+    
+    columns=['stand','walk','jog','run','crouch','jump','crawl','unknown']
+    columns_index=[1,2,4,5,6,7,8]
+    feature_dict=dict(zip(columns,columns_index))
+    
+    #->dataframe
+    a = np.zeros((frames,8))
+    A = pd.DataFrame(a,columns=['stand','walk','jog','run','crouch','jump','crawl','unknown'],index=list(range(1,frames+1)))
+    
+    #->gait
+    for i in range(len(list1)-1):
+        if list1[i] == list1[i+1]:
+            A[list1[i]].loc[eval(list2[i]):eval(list2[i+1])-1] = A[list1[i]].loc[eval(list2[i]):eval(list2[i+1])-1].apply(lambda x:x+1)
+            
+        elif feature_dict[list1[i]]<feature_dict[list1[i+1]]:
+            A[list1[i]].loc[eval(list2[i]):eval(list2[i+1])-1] = np.linspace(1,0,eval(list2[i+1])-eval(list2[i]),endpoint=True)
+            A[list1[i+1]].loc[eval(list2[i]):eval(list2[i+1])-1] = np.linspace(0,1,eval(list2[i+1])-eval(list2[i]),endpoint=True)
+        
+        elif feature_dict[list1[i]]>feature_dict[list1[i+1]]:
+            A[list1[i]].loc[eval(list2[i]):eval(list2[i+1])-1] = np.linspace(1,0,eval(list2[i+1])-eval(list2[i]),endpoint=True)
+            A[list1[i+1]].loc[eval(list2[i]):eval(list2[i+1])-1] = np.linspace(0,1,eval(list2[i+1])-eval(list2[i]),endpoint=True)    
+    A[list1[-1]].loc[eval(list2[-1]):] = A[list1[-1]].loc[eval(list2[-1]):].apply(lambda x:x+1)
+    
+    #->unknown
+    if list3 and txt!='WalkingUpSteps10_000_gait.txt':          
+        for i in range(len(list3)-1)[::2]:
+                A['unknown'].loc[eval(list4[i]):eval(list4[i+1])-1] = A['unknown'].loc[eval(list4[i]):eval(list4[i+1])-1].apply(lambda x:x+1)
+    else:
+        list3=list3[:16]+list3[18:]
+        list4=list4[:16]+list4[18:]
+        for i in range(len(list3)-1)[::2]:
+            A['unknown'].loc[eval(list4[i]):eval(list4[i+1])-1] = A['unknown'].loc[eval(list4[i]):eval(list4[i+1])-1].apply(lambda x:x+1) 
+    
+    A.to_csv(r'{}.gait'.format(os.path.splitext(bvh)[0]),float_format='%.5f',header=False, index=False,sep=' ')
+    A.to_csv(r'{}_mirror.gait'.format(os.path.splitext(bvh)[0]),float_format='%.5f',header=False, index=False,sep=' ')
+    
+
+if __name__=='__main__':
+    path = r'./data/animations_xxx'
+    l1=[]
+    for file in os.listdir(path):
+        if re.match(r'(\w+).bvh|(\w+)_gait.txt',file):        
+            l1.append(file)  
+    #print(l1)
+            
+    for i in range(len(l1))[::2]:
+        if l1[i+1].split('.')[0] == l1[i].split('.')[0]+'_gait':
+            gait(path+'/'+l1[i],path+'/'+l1[i+1])
+     
+    

--- a/generate_database.py
+++ b/generate_database.py
@@ -4,6 +4,8 @@ import numpy as np
 import scipy.interpolate as interpolate
 import scipy.ndimage.filters as filters
 
+import skeletondef as skd
+
 sys.path.append('./motion')
 
 import BVH as BVH
@@ -15,9 +17,9 @@ from Learning import RBF
 """ Options """
 
 rng = np.random.RandomState(1234)
-to_meters = 5.6444
+to_meters = skd.JOINT_SCALE
 window = 60
-njoints = 31
+njoints = skd.JOINT_NUM
 
 """ Data """
 
@@ -111,6 +113,52 @@ data_terrain = [
 
 #data_terrain = ['./data/animations/LocomotionFlat01_000.bvh']
 
+""" filter out joints """
+def filter_joints(anim, names):
+    indices = []
+    for j in range(len(skd.FILTER_OUT)):
+        for i in range(len(names)):
+            if skd.FILTER_OUT[j] in names[i]:
+                indices.append(i)
+    indices = sorted(indices, reverse=True)
+    
+    """
+    #note: if middle joints are filtered out, we need re-calc local xforms
+    #now there's not any, so skip
+    #cache global xform
+    global_xforms = Animation.transforms_global(anim)
+    global_xforms = np.delete(global_xforms, indices)
+    local_xforms = np.zeros(global_xforms.shape)
+    """
+    
+    anim.orients = np.delete(anim.orients, indices) #incorrect but not used. 
+    anim.offsets = np.delete(anim.offsets, indices)
+    anim.parents = np.delete(anim.parents, indices)
+    anim.rotations = Quaternions(np.delete(anim.rotations, indices, 1))
+    anim.positions = np.delete(anim.positions, indices, 1)
+
+    names2 = names.copy()
+    for i in indices:
+        del names2[i]
+        for j in range(len(anim.parents)):
+            if anim.parents[j] >= i:
+                anim.parents[j] -= 1
+    
+    """
+    #calc local xform based on stripped global xform
+    invf = lambda x : Animation.transforms_inv(x)
+    inv_xforms = list(map(invf, global_xforms))
+    
+    for i in range(1, anim.shape[1]):
+        local_xforms[:,i] = Animation.transforms_multiply(inv_xforms[:,anim.parents[i]], global_xforms[:,i])
+    
+    anim.rotations = Quaternions.from_transforms(local_xforms)
+    anim.positions = local_xforms[:,:,:3,3] / local_xforms[:,:,3:,3]
+    """
+    
+    return anim, names2
+
+
 """ Load Terrain Patches """
 
 patches_database = np.load('patches.npz')
@@ -128,10 +176,9 @@ def process_data(anim, phase, gait, type='flat'):
     
     """ Extract Forward Direction """
     
-    sdr_l, sdr_r, hip_l, hip_r = 18, 25, 2, 7
     across = (
-        (global_positions[:,sdr_l] - global_positions[:,sdr_r]) + 
-        (global_positions[:,hip_l] - global_positions[:,hip_r]))
+        (global_positions[:,skd.SDR_L] - global_positions[:,skd.SDR_R]) + 
+        (global_positions[:,skd.HIP_L] - global_positions[:,skd.HIP_R]))
     across = across / np.sqrt((across**2).sum(axis=-1))[...,np.newaxis]
     
     """ Smooth Forward Direction """
@@ -153,13 +200,15 @@ def process_data(anim, phase, gait, type='flat'):
     local_positions = root_rotation[:-1] * local_positions[:-1]
     local_velocities = root_rotation[:-1] *  (global_positions[1:] - global_positions[:-1])
     local_rotations = abs((root_rotation[:-1] * global_rotations[:-1])).log()
+    #print('hips (w,x,y,z)=' + str(abs((root_rotation[:-1] * global_rotations[:-1]))[0][0]))
+    #print('hips log(w,x,y,z)=' + str(local_rotations[0][0]))
     
     root_velocity = root_rotation[:-1] * (global_positions[1:,0:1] - global_positions[:-1,0:1])
     root_rvelocity = Pivots.from_quaternions(root_rotation[1:] * -root_rotation[:-1]).ps
     
     """ Foot Contacts """
     
-    fid_l, fid_r = np.array([4,5]), np.array([9,10])
+    fid_l, fid_r = np.array(skd.FOOT_L), np.array(skd.FOOT_R)
     velfactor = np.array([0.02, 0.02])
     
     feet_l_x = (global_positions[1:,fid_l,0] - global_positions[:-1,fid_l,0])**2
@@ -181,7 +230,7 @@ def process_data(anim, phase, gait, type='flat'):
     
     if type == 'flat':
         crouch_low, crouch_high = 80, 130
-        head = 16
+        head = skd.HEAD
         gait[:-1,3] = 1 - np.clip((global_positions[:-1,head,1] - 80) / (130 - 80), 0, 1)
         gait[-1,3] = gait[-2,3]
 
@@ -257,10 +306,9 @@ def process_heights(anim, nsamples=10, type='flat'):
     
     """ Extract Forward Direction """
     
-    sdr_l, sdr_r, hip_l, hip_r = 18, 25, 2, 7
     across = (
-        (global_positions[:,sdr_l] - global_positions[:,sdr_r]) + 
-        (global_positions[:,hip_l] - global_positions[:,hip_r]))
+        (global_positions[:,skd.SDR_L] - global_positions[:,skd.SDR_R]) + 
+        (global_positions[:,skd.HIP_L] - global_positions[:,skd.HIP_R]))
     across = across / np.sqrt((across**2).sum(axis=-1))[...,np.newaxis]
     
     """ Smooth Forward Direction """
@@ -275,7 +323,7 @@ def process_heights(anim, nsamples=10, type='flat'):
 
     """ Foot Contacts """
     
-    fid_l, fid_r = np.array([4,5]), np.array([9,10])
+    fid_l, fid_r = np.array(skd.FOOT_L), np.array(skd.FOOT_R)
     velfactor = np.array([0.02, 0.02])
     
     feet_l_x = (global_positions[1:,fid_l,0] - global_positions[:-1,fid_l,0])**2
@@ -314,13 +362,11 @@ def process_heights(anim, nsamples=10, type='flat'):
     ], axis=0)
     
     """ Down Locations """
-    
     feet_down_xz = np.concatenate([feet_down[:,0:1], feet_down[:,2:3]], axis=-1)
     feet_down_xz_mean = feet_down_xz.mean(axis=0)
     feet_down_y = feet_down[:,1:2]
     feet_down_y_mean = feet_down_y.mean(axis=0)
     feet_down_y_std  = feet_down_y.std(axis=0)
-        
     """ Up Locations """
         
     feet_up_xz = np.concatenate([feet_up[:,0:1], feet_up[:,2:3]], axis=-1)
@@ -408,9 +454,8 @@ def process_heights(anim, nsamples=10, type='flat'):
             terr_down_y_mean[terr_ids][:,np.newaxis]) + feet_down_y_mean)
         
         """ Terrain Fit Editing """
-        
         terr_residuals = feet_down_y - terr_basic_func(feet_down_xz)
-        terr_fine_func = [RBF(smooth=0.1, function='linear') for _ in range(nsamples)]
+        terr_fine_func = [RBF(smooth=0.1, function='linear', epsilon=1e-10) for _ in range(nsamples)]
         for i in range(nsamples): terr_fine_func[i].fit(feet_down_xz, terr_residuals[i])
         terr_func = lambda Xp: (terr_basic_func(Xp) + np.array([ff(Xp) for ff in terr_fine_func]))
         
@@ -469,9 +514,21 @@ for data in data_terrain:
     """ Load Data """
     
     anim, names, _ = BVH.load(data)
+    anim, names = filter_joints(anim, names)
     anim.offsets *= to_meters
     anim.positions *= to_meters
     anim = anim[::2]
+	
+    """ Dump joint lists"""
+    #print(names)
+    with open("jointlist.txt", "w") as f:
+        for j in range(len(names)):
+            jname = names[j]
+            p = anim.parents[j]
+            while p!=-1:
+                jname = names[p] + "/" + jname
+                p = anim.parents[p]
+            f.writelines("\"" + jname + "\",\n")
 
     """ Load Phase / Gait """
     
@@ -541,6 +598,8 @@ print('Total Clips: %i' % len(X))
 print('Shortest Clip: %i' % min(map(len,X)))
 print('Longest Clip: %i' % max(map(len,X)))
 print('Average Clip: %i' % np.mean(list(map(len,X))))
+#print("YP0: %3.3f %3.3f %3.3f" %(float(Y[0][0][32]), float(Y[0][0][33]), float(Y[0][0][34])) )
+#print("YR0: %3.4f %3.4f %3.4f" %(float(Y[0][0][218]), float(Y[0][0][219]), float(Y[0][0][220])) )
 
 """ Merge Clips """
 

--- a/motion/Quaternions.py
+++ b/motion/Quaternions.py
@@ -140,7 +140,7 @@ class Quaternions:
         return Quaternions(self.qs * np.array([[1, -1, -1, -1]]))
     
     def __abs__(self):
-        """ Unify Quaternions To Single Pole """
+        """ Limit angles to 180 """
         qabs = self.normalized().copy()
         top = np.sum(( qabs.qs) * np.array([1,0,0,0]), axis=-1)
         bot = np.sum((-qabs.qs) * np.array([1,0,0,0]), axis=-1)
@@ -175,7 +175,7 @@ class Quaternions:
         return Quaternions(self.qs / self.lengths[...,np.newaxis])
     
     def log(self):
-        norm = abs(self.normalized())
+        norm = self.normalized()
         imgs = norm.imaginaries
         lens = np.sqrt(np.sum(imgs**2, axis=-1))
         lens = np.arctan2(lens, norm.reals) / (lens + 1e-10)

--- a/preprocess_footstep_phase.py
+++ b/preprocess_footstep_phase.py
@@ -1,0 +1,293 @@
+"""
+Generate footsetp & phase from BVH
+Author: Crazii(Xiaofeng)
+"""
+
+import sys
+import os
+import numpy as np
+import scipy.interpolate as interpolate
+import scipy.ndimage.filters as filters
+
+sys.path.append('./motion')
+
+import BVH as BVH
+import Animation as Animation
+from Quaternions import Quaternions
+from Pivots import Pivots
+
+to_meters = 5.6444
+njoints = 31
+
+lfoot = 4
+rfoot = 9
+ltoe = 5
+rtoe = 10
+
+data_terrain = [
+    './data/animations/LocomotionFlat01_000.bvh',
+    './data/animations/LocomotionFlat02_000.bvh',
+    './data/animations/LocomotionFlat02_001.bvh',
+    './data/animations/LocomotionFlat03_000.bvh',
+    './data/animations/LocomotionFlat04_000.bvh',
+    './data/animations/LocomotionFlat05_000.bvh',
+    './data/animations/LocomotionFlat06_000.bvh',
+    './data/animations/LocomotionFlat06_001.bvh',
+    './data/animations/LocomotionFlat07_000.bvh',
+    './data/animations/LocomotionFlat08_000.bvh',
+    './data/animations/LocomotionFlat08_001.bvh',
+    './data/animations/LocomotionFlat09_000.bvh',
+    './data/animations/LocomotionFlat10_000.bvh',
+    './data/animations/LocomotionFlat11_000.bvh',
+    './data/animations/LocomotionFlat12_000.bvh',
+
+    './data/animations/LocomotionFlat01_000_mirror.bvh',
+    './data/animations/LocomotionFlat02_000_mirror.bvh',
+    './data/animations/LocomotionFlat02_001_mirror.bvh',
+    './data/animations/LocomotionFlat03_000_mirror.bvh',
+    './data/animations/LocomotionFlat04_000_mirror.bvh',
+    './data/animations/LocomotionFlat05_000_mirror.bvh',
+    './data/animations/LocomotionFlat06_000_mirror.bvh',
+    './data/animations/LocomotionFlat06_001_mirror.bvh',
+    './data/animations/LocomotionFlat07_000_mirror.bvh',
+    './data/animations/LocomotionFlat08_000_mirror.bvh',
+    './data/animations/LocomotionFlat08_001_mirror.bvh',
+    './data/animations/LocomotionFlat09_000_mirror.bvh',
+    './data/animations/LocomotionFlat10_000_mirror.bvh',
+    './data/animations/LocomotionFlat11_000_mirror.bvh',
+    './data/animations/LocomotionFlat12_000_mirror.bvh',
+
+    './data/animations/WalkingUpSteps01_000.bvh',
+    './data/animations/WalkingUpSteps02_000.bvh',
+    './data/animations/WalkingUpSteps03_000.bvh',
+    './data/animations/WalkingUpSteps04_000.bvh',
+    './data/animations/WalkingUpSteps04_001.bvh',
+    './data/animations/WalkingUpSteps05_000.bvh',
+    './data/animations/WalkingUpSteps06_000.bvh',
+    './data/animations/WalkingUpSteps07_000.bvh',
+    './data/animations/WalkingUpSteps08_000.bvh',
+    './data/animations/WalkingUpSteps09_000.bvh',
+    './data/animations/WalkingUpSteps10_000.bvh',
+    './data/animations/WalkingUpSteps11_000.bvh',
+    './data/animations/WalkingUpSteps12_000.bvh',
+
+    './data/animations/WalkingUpSteps01_000_mirror.bvh',
+    './data/animations/WalkingUpSteps02_000_mirror.bvh',
+    './data/animations/WalkingUpSteps03_000_mirror.bvh',
+    './data/animations/WalkingUpSteps04_000_mirror.bvh',
+    './data/animations/WalkingUpSteps04_001_mirror.bvh',
+    './data/animations/WalkingUpSteps05_000_mirror.bvh',
+    './data/animations/WalkingUpSteps06_000_mirror.bvh',
+    './data/animations/WalkingUpSteps07_000_mirror.bvh',
+    './data/animations/WalkingUpSteps08_000_mirror.bvh',
+    './data/animations/WalkingUpSteps09_000_mirror.bvh',
+    './data/animations/WalkingUpSteps10_000_mirror.bvh',
+    './data/animations/WalkingUpSteps11_000_mirror.bvh',
+    './data/animations/WalkingUpSteps12_000_mirror.bvh',
+
+    './data/animations/NewCaptures01_000.bvh',
+    './data/animations/NewCaptures02_000.bvh',
+    './data/animations/NewCaptures03_000.bvh',
+    './data/animations/NewCaptures03_001.bvh',
+    './data/animations/NewCaptures03_002.bvh',
+    './data/animations/NewCaptures04_000.bvh',
+    './data/animations/NewCaptures05_000.bvh',
+    './data/animations/NewCaptures07_000.bvh',
+    './data/animations/NewCaptures08_000.bvh',
+    './data/animations/NewCaptures09_000.bvh',
+    './data/animations/NewCaptures10_000.bvh',
+    './data/animations/NewCaptures11_000.bvh',
+
+    './data/animations/NewCaptures01_000_mirror.bvh',
+    './data/animations/NewCaptures02_000_mirror.bvh',
+    './data/animations/NewCaptures03_000_mirror.bvh',
+    './data/animations/NewCaptures03_001_mirror.bvh',
+    './data/animations/NewCaptures03_002_mirror.bvh',
+    './data/animations/NewCaptures04_000_mirror.bvh',
+    './data/animations/NewCaptures05_000_mirror.bvh',
+    './data/animations/NewCaptures07_000_mirror.bvh',
+    './data/animations/NewCaptures08_000_mirror.bvh',
+    './data/animations/NewCaptures09_000_mirror.bvh',
+    './data/animations/NewCaptures10_000_mirror.bvh',
+    './data/animations/NewCaptures11_000_mirror.bvh',
+]
+
+for data in data_terrain:
+
+	print('Processing Clip %s' % data)
+	
+	footsteps = []
+	
+	""" Load Data """
+	
+	anim, names, _ = BVH.load(data)
+	anim.offsets *= to_meters
+	anim.positions *= to_meters
+	#anim = anim[::2]
+	global_xforms = Animation.transforms_global(anim)
+	global_positions = global_xforms[:,:,:3,3] / global_xforms[:,:,3:,3]
+	tlen = len(global_positions)
+	#print(tlen)
+	
+	avg_lfs = 0
+	avg_lts = 0
+	avg_rfs = 0
+	avg_rts = 0
+
+	AVG_WINDOW = 5
+	AVG_RANGE = int((AVG_WINDOW-1)/2)
+	# RANGE_LFS = [0 for x in range(AVG_WINDOW)]
+	# RANGE_LTS = [0 for x in range(AVG_WINDOW)]
+	# RANGE_RFS = [0 for x in range(AVG_WINDOW)]
+	# RANGE_RTS = [0 for x in range(AVG_WINDOW)]
+	# for j in range(0, AVG_WINDOW, 1):
+		# RANGE_LFS[j] = np.linalg.norm(global_positions[1+j,lfoot] - global_positions[j,lfoot])
+		# RANGE_LTS[j] = np.linalg.norm(global_positions[1+j,ltoe] - global_positions[j,ltoe])
+		# RANGE_RFS[j] = np.linalg.norm(global_positions[1+j,rfoot] - global_positions[j,rfoot])
+		# RANGE_RTS[j] = np.linalg.norm(global_positions[1+j,rtoe] - global_positions[j,rtoe])
+	# avg_lfs = np.mean(RANGE_LFS)
+	# avg_lts = np.mean(RANGE_LTS)
+	# avg_rfs = np.mean(RANGE_RFS)
+	# avg_rts = np.mean(RANGE_RTS)
+
+	LR = 0
+	for i in range(AVG_RANGE, tlen-AVG_RANGE-1, 1):
+		#ACC_EPSILON = 0
+		ACC_EPSILON = 0.175
+		#ACC_EPSILON = 0.006
+		MULTIPLIER = 2.875
+		LHEEL_SPEED_EPSILON = 0.375
+		RHEEL_SPEED_EPSILON = 0.375
+		LTOE_SPEED_EPSILON = 0.0875
+		RTOE_SPEED_EPSILON = 0.0875
+		# LHEEL_SPEED_EPSILON = avg_lfs * 0.285
+		# RHEEL_SPEED_EPSILON = avg_rfs * 0.285
+		# LTOE_SPEED_EPSILON = avg_lts * 0.285
+		# RTOE_SPEED_EPSILON = avg_rts * 0.285
+
+		LFS = np.linalg.norm(global_positions[i,lfoot] - global_positions[i-1,lfoot]) # left foot
+		LTS = np.linalg.norm(global_positions[i,ltoe] - global_positions[i-1,ltoe]) # left toe	
+		RFS = np.linalg.norm(global_positions[i,rfoot] - global_positions[i-1,rfoot])
+		RTS = np.linalg.norm(global_positions[i,rtoe] - global_positions[i-1,rtoe]) 
+
+		# #uppdate average
+		# RANGE_LFS.append(np.linalg.norm(global_positions[i+AVG_RANGE,lfoot] - global_positions[i+AVG_RANGE-1,lfoot]))
+		# RANGE_LTS.append(np.linalg.norm(global_positions[i+AVG_RANGE,ltoe] - global_positions[i+AVG_RANGE-1,ltoe]))
+		# RANGE_RFS.append(np.linalg.norm(global_positions[i+AVG_RANGE,rfoot] - global_positions[i+AVG_RANGE-1,rfoot]))
+		# RANGE_RTS.append(np.linalg.norm(global_positions[i+AVG_RANGE,rtoe] - global_positions[i+AVG_RANGE-1,rtoe]))
+	
+		# avg_lfs -= RANGE_LFS[0]/AVG_WINDOW
+		# avg_lfs += RANGE_LFS[-1]/AVG_WINDOW
+		# avg_lts -= RANGE_LTS[0]/AVG_WINDOW
+		# avg_lts += RANGE_LTS[-1]/AVG_WINDOW
+		# avg_rfs -= RANGE_RFS[0]/AVG_WINDOW
+		# avg_rfs += RANGE_RFS[-1]/AVG_WINDOW
+		# avg_rts -= RANGE_RTS[0]/AVG_WINDOW
+		# avg_rts += RANGE_RTS[-1]/AVG_WINDOW
+		
+		# RANGE_LFS.pop(0)
+		# RANGE_LTS.pop(0)
+		# RANGE_RFS.pop(0)
+		# RANGE_RTS.pop(0)
+		# #end update average
+						
+		if LR != -1: #and LHEEL_SPEED_EPSILON > 0.001 and LTOE_SPEED_EPSILON > 0.001:
+		
+			OLD_LFS = np.linalg.norm(global_positions[i-1,lfoot] - global_positions[i-2,lfoot]) # left foot
+			OLD_LTS = np.linalg.norm(global_positions[i-1,ltoe] - global_positions[i-2,ltoe])# left toe
+			NEW_LFS = np.linalg.norm(global_positions[i+1,lfoot] - global_positions[i,lfoot]) # left foot
+			NEW_LTS = np.linalg.norm(global_positions[i+1,ltoe] - global_positions[i,ltoe]) # left toe
+
+			#deviate of speed (acceleration)
+			# pi-2   pi-1     pi-1  pi   pi   pi+1
+			#	 \  /            \ /      \  /
+			#    si-1            si      si+1
+			#           \       /   \    /
+			#             -ai        +ai+1
+			dLFS = NEW_LFS - LFS
+			dLTS = NEW_LTS - LTS
+			dOLD_LFS = LFS - OLD_LFS
+			dOLD_LTS = LTS - OLD_LTS
+		
+			if(LFS < LHEEL_SPEED_EPSILON and LTS < LTOE_SPEED_EPSILON \
+			or ((LFS < LHEEL_SPEED_EPSILON*MULTIPLIER and LTS < LTOE_SPEED_EPSILON*MULTIPLIER) and ((dLFS >= ACC_EPSILON and dOLD_LFS <= -ACC_EPSILON) or (dLTS >= ACC_EPSILON and dOLD_LTS < -ACC_EPSILON))) ):
+				if LR == 0:
+					LR = -1
+				if len(footsteps)>0:	#R must start first
+					if LR != -1:
+						LR = -1
+						print("L %d: " %(i))
+						footsteps.append(i)
+
+		elif LR != 1 :#and RHEEL_SPEED_EPSILON > 0.00175 and RTOE_SPEED_EPSILON > 0.00175:
+		
+			OLD_RFS = np.linalg.norm(global_positions[i-1,rfoot] - global_positions[i-2,rfoot])
+			OLD_RTS = np.linalg.norm(global_positions[i-1,rtoe] - global_positions[i-2,rtoe])
+			NEW_RFS = np.linalg.norm(global_positions[i+1,rfoot] - global_positions[i,rfoot])
+			NEW_RTS = np.linalg.norm(global_positions[i+1,rtoe] - global_positions[i,rtoe])
+			dRFS = NEW_RFS - RFS
+			dRTS = NEW_RTS - RTS
+			dOLD_RFS = RFS - OLD_RFS
+			dOLD_RTS = RTS - OLD_RTS
+		
+			if( RFS < RHEEL_SPEED_EPSILON and RTS < RTOE_SPEED_EPSILON \
+			or (RFS < RHEEL_SPEED_EPSILON*MULTIPLIER and RTS < RTOE_SPEED_EPSILON*MULTIPLIER and ((dRFS >= ACC_EPSILON and dOLD_RFS < -ACC_EPSILON) or (dRTS >= ACC_EPSILON and dOLD_RTS < -ACC_EPSILON)))):
+				LR = 1
+				print("R %d: " %(i))
+				footsteps.append(i)
+	
+	#remove redundant frames
+	i = 0
+	deleted = 0
+	while i < len(footsteps):
+		# odd frame number: leave first one and delete the others
+		c = 0
+		while i+c < len(footsteps)-1 and footsteps[i+c+1] - footsteps[i+c] <= 5:
+			c = c + 1
+		if c > 0:
+			c = c + 1
+		if c % 2 == 1 and deleted > 0:
+			i = i + 1
+			
+		while i < len(footsteps)-1 and footsteps[i+1] - footsteps[i] <= 5:
+			del footsteps[i]
+			del footsteps[i]
+			deleted = deleted + 1
+		i=i+1
+	
+	#print(footsteps)
+	f = open(data.replace('.bvh','_footsteps.txt'), 'w')
+	
+	flen = len(footsteps)
+	for i in range(0, int(flen/2), 1):
+		f.writelines("%d %d\n" % (footsteps[i*2], footsteps[i*2+1]) )
+	
+	if flen%2 == 1:
+		f.writelines("%d " % footsteps[flen-1])
+	f.close()
+	
+	f = open(data.replace('.bvh','.phase'), 'w')
+	
+	for i in range(0, footsteps[0]):
+		f.writelines("%f\n" % float(0) )
+		
+	for i in range(0, flen-2, 2):
+		d = float(footsteps[i+1]-footsteps[i])
+		for j in range(footsteps[i], footsteps[i+1], 1):
+			f.writelines("%f\n" % (float(j - footsteps[i]) / d * 0.5) )
+			#print("%f\n" % (float(j - footsteps[i]) / d * 0.5), f)
+			
+		d = float(footsteps[i+2]-footsteps[i+1])
+		for j in range(footsteps[i+1], footsteps[i+2], 1):
+			f.writelines("%f\n" % (float(j - footsteps[i+1]) / d * 0.5 + 0.5) )
+			#print("%f\n" % (float(j - footsteps[i+2]) / d * 0.5), f)
+			
+		#print("%d %d %d " %(footsteps[i], footsteps[i+1], footsteps[i+2]))
+		
+	if (flen-3)%2==1:
+		d = float(footsteps[flen-1]-footsteps[flen-2])
+		for j in range(footsteps[flen-2], footsteps[flen-1], 1):
+			f.writelines("%f\n" % (float(j - footsteps[flen-2]) / d * 0.5) )
+		
+	for i in range(footsteps[flen-1], tlen, 1):
+		f.writelines("%f\n" % float(0) )

--- a/preprocess_footstep_phase_stat.py
+++ b/preprocess_footstep_phase_stat.py
@@ -1,0 +1,271 @@
+"""
+statistics for footsetp & phase generation (preprocess_footstep_pahse.py)
+Author: Xiaofeng
+"""
+
+import sys
+import os
+import numpy as np
+import scipy.interpolate as interpolate
+import scipy.ndimage.filters as filters
+import ctypes
+
+sys.path.append('./motion')
+
+import BVH as BVH
+import Animation as Animation
+from Quaternions import Quaternions
+from Pivots import Pivots
+
+
+# Constants from the Windows API
+STD_OUTPUT_HANDLE = -11
+FOREGROUND_RED    = 0x0004 # text color contains red.
+def get_csbi_attributes(handle):
+    # Based on IPython's winconsole.py, written by Alexander Belchenko
+    import struct
+    csbi = ctypes.create_string_buffer(22)
+    res = ctypes.windll.kernel32.GetConsoleScreenBufferInfo(handle, csbi)
+    assert res
+    (bufx, bufy, curx, cury, wattr,
+    left, top, right, bottom, maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+    return wattr
+
+data_terrain = [
+    './data/animations/LocomotionFlat01_000.bvh',
+    './data/animations/LocomotionFlat02_000.bvh',
+    './data/animations/LocomotionFlat02_001.bvh',
+    './data/animations/LocomotionFlat03_000.bvh',
+    './data/animations/LocomotionFlat04_000.bvh',
+    './data/animations/LocomotionFlat05_000.bvh',
+    './data/animations/LocomotionFlat06_000.bvh',
+    './data/animations/LocomotionFlat06_001.bvh',
+    './data/animations/LocomotionFlat07_000.bvh',
+    './data/animations/LocomotionFlat08_000.bvh',
+    './data/animations/LocomotionFlat08_001.bvh',
+    './data/animations/LocomotionFlat09_000.bvh',
+    './data/animations/LocomotionFlat10_000.bvh',
+    './data/animations/LocomotionFlat11_000.bvh',
+    './data/animations/LocomotionFlat12_000.bvh',
+
+    './data/animations/LocomotionFlat01_000_mirror.bvh',
+    './data/animations/LocomotionFlat02_000_mirror.bvh',
+    './data/animations/LocomotionFlat02_001_mirror.bvh',
+    './data/animations/LocomotionFlat03_000_mirror.bvh',
+    './data/animations/LocomotionFlat04_000_mirror.bvh',
+    './data/animations/LocomotionFlat05_000_mirror.bvh',
+    './data/animations/LocomotionFlat06_000_mirror.bvh',
+    './data/animations/LocomotionFlat06_001_mirror.bvh',
+    './data/animations/LocomotionFlat07_000_mirror.bvh',
+    './data/animations/LocomotionFlat08_000_mirror.bvh',
+    './data/animations/LocomotionFlat08_001_mirror.bvh',
+    './data/animations/LocomotionFlat09_000_mirror.bvh',
+    './data/animations/LocomotionFlat10_000_mirror.bvh',
+    './data/animations/LocomotionFlat11_000_mirror.bvh',
+    './data/animations/LocomotionFlat12_000_mirror.bvh',
+
+    './data/animations/WalkingUpSteps01_000.bvh',
+    './data/animations/WalkingUpSteps02_000.bvh',
+    './data/animations/WalkingUpSteps03_000.bvh',
+    './data/animations/WalkingUpSteps04_000.bvh',
+    './data/animations/WalkingUpSteps04_001.bvh',
+    './data/animations/WalkingUpSteps05_000.bvh',
+    './data/animations/WalkingUpSteps06_000.bvh',
+    './data/animations/WalkingUpSteps07_000.bvh',
+    './data/animations/WalkingUpSteps08_000.bvh',
+    './data/animations/WalkingUpSteps09_000.bvh',
+    './data/animations/WalkingUpSteps10_000.bvh',
+    './data/animations/WalkingUpSteps11_000.bvh',
+    './data/animations/WalkingUpSteps12_000.bvh',
+
+    './data/animations/WalkingUpSteps01_000_mirror.bvh',
+    './data/animations/WalkingUpSteps02_000_mirror.bvh',
+    './data/animations/WalkingUpSteps03_000_mirror.bvh',
+    './data/animations/WalkingUpSteps04_000_mirror.bvh',
+    './data/animations/WalkingUpSteps04_001_mirror.bvh',
+    './data/animations/WalkingUpSteps05_000_mirror.bvh',
+    './data/animations/WalkingUpSteps06_000_mirror.bvh',
+    './data/animations/WalkingUpSteps07_000_mirror.bvh',
+    './data/animations/WalkingUpSteps08_000_mirror.bvh',
+    './data/animations/WalkingUpSteps09_000_mirror.bvh',
+    './data/animations/WalkingUpSteps10_000_mirror.bvh',
+    './data/animations/WalkingUpSteps11_000_mirror.bvh',
+    './data/animations/WalkingUpSteps12_000_mirror.bvh',
+
+    './data/animations/NewCaptures01_000.bvh',
+    './data/animations/NewCaptures02_000.bvh',
+    './data/animations/NewCaptures03_000.bvh',
+    './data/animations/NewCaptures03_001.bvh',
+    './data/animations/NewCaptures03_002.bvh',
+    './data/animations/NewCaptures04_000.bvh',
+    './data/animations/NewCaptures05_000.bvh',
+    './data/animations/NewCaptures07_000.bvh',
+    './data/animations/NewCaptures08_000.bvh',
+    './data/animations/NewCaptures09_000.bvh',
+    './data/animations/NewCaptures10_000.bvh',
+    './data/animations/NewCaptures11_000.bvh',
+
+    './data/animations/NewCaptures01_000_mirror.bvh',
+    './data/animations/NewCaptures02_000_mirror.bvh',
+    './data/animations/NewCaptures03_000_mirror.bvh',
+    './data/animations/NewCaptures03_001_mirror.bvh',
+    './data/animations/NewCaptures03_002_mirror.bvh',
+    './data/animations/NewCaptures04_000_mirror.bvh',
+    './data/animations/NewCaptures05_000_mirror.bvh',
+    './data/animations/NewCaptures07_000_mirror.bvh',
+    './data/animations/NewCaptures08_000_mirror.bvh',
+    './data/animations/NewCaptures09_000_mirror.bvh',
+    './data/animations/NewCaptures10_000_mirror.bvh',
+    './data/animations/NewCaptures11_000_mirror.bvh',
+]
+"""
+data_terrain = [
+    #'./data/animations/LocomotionFlat01_000.bvh',
+    #'./data/animations/LocomotionFlat02_000.bvh',
+	#'./data/animations/NewCaptures01_000.bvh',
+	#'./data/animations/LocomotionFlat02_001.bvh',
+	
+	'./data/animations/LocomotionFlat06_000.bvh',
+    #'./data/animations/LocomotionFlat06_001.bvh',
+    #'./data/animations/LocomotionFlat07_000.bvh',
+    #'./data/animations/LocomotionFlat08_000.bvh',
+]
+"""
+phase_error = 0
+frame_total = 0
+
+acc_step_error = 0
+acc_step_count_error = 0
+acc_neg_step_count_error = 0
+step_total = 0
+
+for data in data_terrain:
+
+	#phases
+	f0 = data.replace('.bvh','.phase')
+	f1 = data.replace('.bvh','_2.phase')
+	
+	phase0 = np.loadtxt(f0)
+	phase1= np.loadtxt(f1)
+	
+	frame_count0 = len(phase0)
+	frame_count1 = len(phase1)
+	if frame_count0 != frame_count1:
+		print("%s %d : %s %d" % (f0, frame_count0, f1, frame_count1))
+		raise ("invalid input.")
+
+	err = 0
+	for i in range(0,frame_count0,1):
+		err += np.abs(phase0[i]-phase1[i])
+		
+	phase_error += err
+	frame_total += frame_count0
+	
+	
+	#steps
+	f0 = data.replace('.bvh','_footsteps.txt')
+	f1 = data.replace('.bvh','_footsteps_2.txt')
+	
+	with open(f0, 'r') as _f0:
+		footsteps = _f0.readlines()
+	
+	steps0 = [[0 for x in range(2)] for y in range(len(footsteps))]		
+	for i in range(len(footsteps)-1):
+		step = footsteps[i].split(' ')
+		if len(step) >= 2:
+			steps0[i][0] = int(step[0])
+			steps0[i][1] = int(step[1])
+		
+	with open(f1, 'r') as _f1:
+		footsteps = _f1.readlines()
+	steps1 = [[0 for x in range(2)] for y in range(len(footsteps))]
+	for i in range(len(footsteps)-1):
+		step = footsteps[i].split(' ')
+		if len(step) >= 2:
+			steps1[i][0] = int(step[0])
+			steps1[i][1] = int(step[1])
+		
+	step_count0 = len(steps0)
+	step_count1 = len(steps1)
+	step_total += step_count0
+
+	steperror = 0
+	stepcount_positive = 0
+	stepcount_negative = 0
+	
+	# if step_count1-step_count0 >= 0:
+		# stepcount_positive = step_count1-step_count0
+	# else:
+		# stepcount_negative = step_count1-step_count0
+	stepcounterror = 0#stepcounterror = abs(step_count1-step_count0)
+	
+	b0 = 0
+	b1 = 0
+	miss0 = 0
+	miss1 = 0
+	threshold = 25
+	#threshold = max(min(int(0.00222 * frame_count0), 40),5)
+	for i in range(0,min(step_count0, step_count1),1):
+		if i+b0 < len(steps0) and i + b1 < len(steps1):
+			#print("%d:[%d,%d] %d:[%d,%d]" % (i+b0, steps0[i+b0][0], steps0[i+b0][1], i+b1, steps1[i+b1][0], steps1[i+b1][1]))
+			if (abs(steps0[i+b0][0]-steps1[i+b1][0]) <= threshold and abs(steps0[i+b0][1]-steps1[i+b1][1]) <= threshold) \
+			or (abs(steps0[i+b0][0]-steps1[i+b1][0]) + abs(steps0[i+b0][1]-steps1[i+b1][1]))/2 <= threshold:
+				steperror += abs(steps0[i+b0][0] - steps1[i+b1][0])
+				steperror += abs(steps0[i+b0][1] - steps1[i+b1][1])
+				miss0 = 0
+				miss1 = 0
+				#print("%f %f %f" %(abs(steps0[i+b0][0] - steps1[i+b1][0]),abs(steps0[i+b0][1] - steps1[i+b1][1]), steperror))
+				#print("YES")
+			else:
+				#print("[%f,%f] : [%f,%f]" % (steps0[i+b0][0], steps0[i+b0][1], steps1[i+b1][0], steps1[i+b1][1]))
+				#print("%d, %d == [%f,%f] : [%f,%f]" % (miss0, miss1, steps0[i+b0][0], steps0[i+b0][1], steps1[i+b1][0], steps1[i+b1][1]))
+				if miss0 != miss1 or miss0 == 0:
+					stepcounterror = stepcounterror+1
+					#print("%d:[%d,%d] %d:[%d,%d]" % (i+b0, steps0[i+b0][0], steps0[i+b0][1], i+b1, steps1[i+b1][0], steps1[i+b1][1]))
+					#print("NO")
+					if steps0[i+b0][0]-steps1[i+b1][0] >= 25 or steps0[i+b0][1]-steps1[i+b1][1] >= 25:
+						stepcount_positive += 1
+						#print("+[%f,%f] : [%f,%f]" % (steps0[i+b0][0], steps0[i+b0][1], steps1[i+b1][0], steps1[i+b1][1]))
+						# if miss0 != miss1 -1:
+							# print("[%f,%f] : [%f,%f]" % (steps0[i+b0][0], steps0[i+b0][1], steps1[i+b1][0], steps1[i+b1][1]))
+					else:
+						if miss0 != miss1 - 1:
+							#print("-[%f,%f] : [%f,%f]" % (steps0[i+b0][0], steps0[i+b0][1], steps1[i+b1][0], steps1[i+b1][1]))
+							#print("%d, %d == [%f,%f] : [%f,%f]" % (miss0, miss1, steps0[i+b0][0], steps0[i+b0][1], steps1[i+b1][0], steps1[i+b1][1]))
+							stepcount_negative -= 1
+					
+				if steps0[i+b0][0]-steps1[i+b1][0] >= 25 or steps0[i+b0][1]-steps1[i+b1][1] >= 25:
+					#b1 = b1 + 1
+					b0 = b0 - 1
+					miss1 = miss1 + 1
+				else:
+					#b0 = b0 + 1
+					b1 = b1 - 1
+					miss0 = miss0 + 1
+
+	#red color
+	console_handle = 0
+	if stepcount_negative != 0:
+		console_handle = ctypes.windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+		reset = get_csbi_attributes(console_handle)
+		ctypes.windll.kernel32.SetConsoleTextAttribute(console_handle, FOREGROUND_RED)
+	
+	print("%s phase error: %f step error: %f, stepcount error: %f, +stepcount %f, -stepcount %f "\
+	%(f0, err/frame_count0, steperror/frame_count0, stepcounterror/ step_count0, stepcount_positive/step_count0, stepcount_negative/step_count0))
+	
+	#end red color
+	if stepcount_negative != 0:
+		ctypes.windll.kernel32.SetConsoleTextAttribute(console_handle, reset)
+	
+	acc_step_count_error += stepcounterror
+	acc_step_error += steperror
+	acc_neg_step_count_error += stepcount_negative
+	
+total = len(data_terrain)
+
+print("total original steps: %f" %(step_total))
+print("acc phase error: %f" %(phase_error/frame_total))
+print("acc step error: %f" %(acc_step_error/frame_total))
+print("acc step count error: %f" %(acc_step_count_error/step_total))
+print("acc negative step count error: %f" %(abs(acc_neg_step_count_error/step_total)))
+

--- a/skeletondef.py
+++ b/skeletondef.py
@@ -1,0 +1,120 @@
+"""
+ROOT Hips
+JOINT LHipJoint
+	JOINT LeftUpLeg
+		JOINT LeftLeg
+			JOINT LeftFoot
+				JOINT LeftToeBase
+JOINT RHipJoint
+	JOINT RightUpLeg
+		JOINT RightLeg
+			JOINT RightFoot
+				JOINT RightToeBase
+JOINT LowerBack
+	JOINT Spine
+		JOINT Spine1
+			JOINT Neck
+				JOINT Neck1
+					JOINT Head
+			JOINT LeftShoulder
+				JOINT LeftArm
+						JOINT LeftForeArm
+							JOINT LeftHand
+								JOINT LeftFingerBase
+									JOINT LeftHandIndex1
+								JOINT LThumb
+				JOINT RightShoulder
+					JOINT RightArm
+						JOINT RightForeArm
+							JOINT RightHand
+								JOINT RightFingerBase
+									JOINT RightHandIndex1
+								JOINT RThumb
+"""
+
+"""
+JOINT_NUM = 31
+
+SDR_L, SDR_R, HIP_L, HIP_R = 18, 25, 2, 7
+FOOT_L = [4,5]
+FOOT_R = [9,10]
+HEAD = 16
+FILTER_OUT = []
+JOINT_SCALE = 5.644
+
+JOINT_WEIGHTS = [
+    1,
+    1e-10, 1, 1, 1, 1,
+    1e-10, 1, 1, 1, 1,
+    1e-10, 1, 1,
+    1e-10, 1, 1,
+    1e-10, 1, 1, 1, 1e-10, 1e-10, 1e-10,
+    1e-10, 1, 1, 1, 1e-10, 1e-10, 1e-10 ]
+"""
+
+"""
+ROOT
+JOINT Hip_R
+  JOINT HipPart1_R
+    JOINT HipPart2_R
+      JOINT Knee_R
+        JOINT KneePart1_R
+          JOINT KneePart2_R
+            JOINT Ankle_R
+              JOINT Toes_R
+                JOINT ToesEnd_R
+JOINT Spine1_M
+  JOINT Spine2_M
+    JOINT Spine3_M
+      JOINT Chest_M
+        JOINT Scapula_R
+          JOINT Shoulder_R
+            JOINT ShoulderPart1_R
+              JOINT ShoulderPart2_R
+                JOINT Elbow_R
+                  JOINT ElbowPart1_R
+                    JOINT ElbowPart2_R
+                      JOINT Wrist_R
+         JOINT Neck_M
+           JOINT NeckPart1_M
+             JOINT Head_M
+               JOINT HeadEnd_M
+               JOINT Head_M_spare
+          JOINT Scapula_L
+            JOINT Shoulder_L
+              JOINT ShoulderPart1_L
+                JOINT ShoulderPart2_L
+                  JOINT Elbow_L
+                    JOINT ElbowPart1_L
+                      JOINT ElbowPart2_L
+                        JOINT Wrist_L
+  JOINT Hip_L
+    JOINT HipPart1_L
+      JOINT HipPart2_L
+        JOINT Knee_L
+          JOINT KneePart1_L
+            JOINT KneePart2_L
+              JOINT Ankle_L
+                JOINT Toes_L
+                  JOINT ToesEnd_L
+"""
+
+#"""
+JOINT_NUM = 44
+
+SDR_L, SDR_R, HIP_L, HIP_R = 28, 15, 35, 1
+FOOT_L = [41,43]
+FOOT_R = [7,9]
+HEAD = 24
+FILTER_OUT = ["Cup", "Finger", "Head_rivet", "Teeth", "Tongue", "Eye", "Pupil", "Iris", "muscleDriver"]
+JOINT_SCALE = 1
+
+JOINT_WEIGHTS = [
+    1,
+    1, 1e-10, 1e-10, 1, 1e-10, 1e-10, 1, 1e-10, 1,
+	1, 1, 1, 1,
+	            1e-10, 1, 1e-10, 1e-10, 1, 1e-10, 1e-10, 1,
+				1, 1e-10, 1, 1e-10, 1e-10,
+	            1e-10, 1, 1e-10, 1e-10, 1, 1e-10, 1e-10, 1,
+    1, 1e-10, 1e-10, 1, 1e-10, 1e-10, 1, 1e-10, 1 ]
+#"""

--- a/train_pfnn.py
+++ b/train_pfnn.py
@@ -2,6 +2,7 @@ import sys
 import numpy as np
 import theano
 import theano.tensor as T
+import skeletondef as skd
 theano.config.allow_gc = True
 
 sys.path.append('./nn')
@@ -29,7 +30,7 @@ print(X.shape, Y.shape)
 Xmean, Xstd = X.mean(axis=0), X.std(axis=0)
 Ymean, Ystd = Y.mean(axis=0), Y.std(axis=0)
 
-j = 31
+j = skd.JOINT_NUM
 w = ((60*2)//10)
 
 Xstd[w*0:w* 1] = Xstd[w*0:w* 1].mean() # Trajectory Past Positions
@@ -40,14 +41,7 @@ Xstd[w*4:w*10] = Xstd[w*4:w*10].mean() # Trajectory Gait
 
 """ Mask Out Unused Joints in Input """
 
-joint_weights = np.array([
-    1,
-    1e-10, 1, 1, 1, 1,
-    1e-10, 1, 1, 1, 1,
-    1e-10, 1, 1,
-    1e-10, 1, 1,
-    1e-10, 1, 1, 1, 1e-10, 1e-10, 1e-10,
-    1e-10, 1, 1, 1, 1e-10, 1e-10, 1e-10]).repeat(3)
+joint_weights = np.array(skd.JOINT_WEIGHTS).repeat(3)
 
 Xstd[w*10+j*3*0:w*10+j*3*1] = Xstd[w*10+j*3*0:w*10+j*3*1].mean() / (joint_weights * 0.1) # Pos
 Xstd[w*10+j*3*1:w*10+j*3*2] = Xstd[w*10+j*3*1:w*10+j*3*2].mean() / (joint_weights * 0.1) # Vel


### PR DESCRIPTION
I've found a bug on custom skeleton & mocap data:
shoulder/scapula/wrist/ankle joint is twisting/rotating unnaturally, ~~as seen here:~~
~~image deleted due to my company's intellectual property issue.~~

As noted in [Grassia1998]: 

> The procedure followed by Yahia [13] of limiting the range of the
log map to |log(r)| ≤ π does not suffice. A log mapping that does guarantee the geodesic approximation picks the mapping for each successive key that minimizes the Euclidean distance to the mapping of the previous key.

The quaternion pole should be unified in a successive manner, between prev & cur rotations.

Please merge this commit **only**:  [a8380de
](https://github.com/crazii/PFNN/commit/a8380de4f0f2926ef2a69ade333f046d681d6cf5)